### PR TITLE
refactor: remove FAST deduplication mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ If path contains space, just backslash space inside path:
 1. Recursively scans folder using filters (min/max size, extension)
 2. Applies one of the initial grouping ways from "boosting" option (size, size+extension, etc)
 3. Further checking depends on mode:
-   * "fast": checks hash-sum of first 128+ KB (false positives very possible)
    * "normal": checks hash-sum of 3 parts of the file: front -> middle -> end (generally reliable)
    * "full": checks hash-sum of front -> middle -> entire file (very slow for large files)  
 4. Shows the list of groups sorted in descending order (groups with larger files come first).   
@@ -103,7 +102,6 @@ Options:
 `**Groups formed above will be checked (hash-checking) in further stages`  
 
 `--mode {fast, normal, full}` checking mode (normal by default)
-* `fast`    check only by hashsum from the front part of file  
 * `normal`  check by hashsum from 3 parts of file  
 * `full`    check by hashsum from 2 part + whole file hashsum  
 

--- a/src/onlyone/aliases.py
+++ b/src/onlyone/aliases.py
@@ -21,7 +21,6 @@ BOOST_HELP_TEXT = (
 )
 
 DEDUP_MODE_ALIASES = {
-    "fast": DeduplicationMode.FAST,
     "normal": DeduplicationMode.NORMAL,
     "full": DeduplicationMode.FULL,
 }
@@ -30,7 +29,6 @@ DEDUP_MODE_CHOICES = list(DEDUP_MODE_ALIASES.keys())
 
 DEDUP_MODE_HELP_TEXT = (
     "Deduplication mode (depth of analysis):\n"
-    "  fast               : Size → Front Hash (fastest, may miss some duplicates)\n"
     "  normal             : Size → Front → Middle → End Hash (balanced)\n"
     "  full               : Size → Front → Middle → Full Hash\n"
     "Example:\n"

--- a/src/onlyone/cli.py
+++ b/src/onlyone/cli.py
@@ -247,7 +247,7 @@ class CLIApplication:
         if args.mode not in DEDUP_MODE_ALIASES:
             self.error_exit(
                 f"Invalid deduplication mode: '{args.mode}'.\n"
-                f"Valid options: {', '.join({'fast', 'normal', 'full'})}"
+                f"Valid options: {', '.join({'normal', 'full'})}"
             )
 
     def create_params(self, args: argparse.Namespace) -> DeduplicationParams:

--- a/src/onlyone/core/deduplicator.py
+++ b/src/onlyone/core/deduplicator.py
@@ -97,9 +97,7 @@ class Deduplicator:
     def _build_pipeline(self, mode: DeduplicationMode) -> List[Tuple[str, Union[PartialHashStageBase, FullHashStage]]]:
         """Builds the appropriate pipeline based on deduplication mode."""
         pipeline = []
-        if mode == DeduplicationMode.FAST:
-            pipeline.append(("front", FrontHashStage(self.grouper)))
-        elif mode == DeduplicationMode.NORMAL:
+        if mode == DeduplicationMode.NORMAL:
             pipeline.append(("front", FrontHashStage(self.grouper)))
             pipeline.append(("middle", MiddleHashStage(self.grouper)))
             pipeline.append(("end", EndHashStage(self.grouper)))

--- a/src/onlyone/core/models.py
+++ b/src/onlyone/core/models.py
@@ -22,7 +22,6 @@ class DeduplicationMode(Enum):
     """
     Deduplication mode controlling the depth of duplicate detection.
     """
-    FAST = "fast"
     NORMAL = "normal"
     FULL = "full"
 
@@ -30,7 +29,6 @@ class DeduplicationMode(Enum):
     def display_name(self) -> str:
         """Human-readable name for UI display."""
         mapping = {
-            DeduplicationMode.FAST: "Fast",
             DeduplicationMode.NORMAL: "Normal",
             DeduplicationMode.FULL: "Full",
         }
@@ -40,8 +38,6 @@ class DeduplicationMode(Enum):
     def description(self) -> str:
         """Detailed description for help text."""
         mapping = {
-            DeduplicationMode.FAST:
-                "Size → Front Hash (fastest, may miss some duplicates)",
             DeduplicationMode.NORMAL:
                 "Size → Front → Middle → End Hash (balanced speed/accuracy)",
             DeduplicationMode.FULL:

--- a/tests/test_argument_parsing.py
+++ b/tests/test_argument_parsing.py
@@ -76,7 +76,7 @@ class TestArgumentParsing:
         """Test --mode flag with valid values."""
         app = CLIApplication()
 
-        for mode in ["fast", "normal", "full"]:
+        for mode in ["normal", "full"]:
             with mock.patch.object(sys, 'argv', ['onlyone', '-i', '/tmp', '--mode', mode]):
                 args = app.parse_args()
             assert args.mode == mode

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -21,15 +21,15 @@ class TestDeduplicationCommand:
         root_dir = str(Path(test_files["dup1_a"]).parent)
 
         params = DeduplicationParams(
-            root_dirs=[root_dir],  # ← FIXED: root_dirs as list
+            root_dirs=[root_dir],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
             favourite_dirs=[],
-            excluded_dirs=[],  # ← ADDED: required parameter
-            mode=DeduplicationMode.FAST,
+            excluded_dirs=[],
+            mode=DeduplicationMode.NORMAL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED: required parameter
+            boost=BoostMode.SAME_SIZE
         )
 
         command = DeduplicationCommand()
@@ -40,6 +40,7 @@ class TestDeduplicationCommand:
         assert stats.grouping_time > 0
         assert "size" in stats.stage_stats
         assert "front" in stats.stage_stats
+        assert "end" in stats.stage_stats
 
     def test_execute_raises_error_on_empty_scan(self, temp_dir):
         """
@@ -47,15 +48,15 @@ class TestDeduplicationCommand:
         Prevents wasted deduplication effort on empty input.
         """
         params = DeduplicationParams(
-            root_dirs=[str(temp_dir)],  # ← FIXED
+            root_dirs=[str(temp_dir)],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],  # No .txt files in empty dir
             favourite_dirs=[],
-            excluded_dirs=[],  # ← ADDED
-            mode=DeduplicationMode.FAST,
+            excluded_dirs=[],
+            mode=DeduplicationMode.NORMAL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED
+            boost=BoostMode.SAME_SIZE
         )
 
         command = DeduplicationCommand()
@@ -75,15 +76,15 @@ class TestDeduplicationCommand:
             progress_events.append((stage, current, total))
 
         params = DeduplicationParams(
-            root_dirs=[root_dir],  # ← FIXED
+            root_dirs=[root_dir],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
             favourite_dirs=[],
-            excluded_dirs=[],  # ← ADDED
-            mode=DeduplicationMode.FAST,
+            excluded_dirs=[],
+            mode=DeduplicationMode.NORMAL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED
+            boost=BoostMode.SAME_SIZE
         )
 
         command = DeduplicationCommand()
@@ -98,7 +99,7 @@ class TestDeduplicationCommand:
 
         # Last events should include hash stages
         last_stage = progress_events[-1][0].lower()
-        assert "front" in last_stage or "hash" in last_stage
+        assert "end" in last_stage or "hash" in last_stage
 
     def test_get_files_returns_copy_of_list(self, test_files):
         """
@@ -108,15 +109,15 @@ class TestDeduplicationCommand:
         root_dir = str(Path(test_files["dup1_a"]).parent)
 
         params = DeduplicationParams(
-            root_dirs=[root_dir],  # ← FIXED
+            root_dirs=[root_dir],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
             favourite_dirs=[],
-            excluded_dirs=[],  # ← ADDED
-            mode=DeduplicationMode.FAST,
+            excluded_dirs=[],
+            mode=DeduplicationMode.NORMAL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED
+            boost=BoostMode.SAME_SIZE
         )
 
         command = DeduplicationCommand()
@@ -155,15 +156,15 @@ class TestDeduplicationCommand:
             return dedupe_call_count > 3
 
         params = DeduplicationParams(
-            root_dirs=[root_dir],  # ← FIXED
+            root_dirs=[root_dir],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
             favourite_dirs=[],
-            excluded_dirs=[],  # ← ADDED
-            mode=DeduplicationMode.FULL,  # Longer pipeline = easier to cancel
+            excluded_dirs=[],
+            mode=DeduplicationMode.FULL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED
+            boost=BoostMode.SAME_SIZE
         )
 
         command = DeduplicationCommand()
@@ -193,13 +194,13 @@ class TestDeduplicationCommand:
         (dir2 / "file2.txt").write_bytes(content)
 
         params = DeduplicationParams(
-            root_dirs=[str(dir1), str(dir2)],  # ← NEW: multiple roots
+            root_dirs=[str(dir1), str(dir2)],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
             favourite_dirs=[],
             excluded_dirs=[],
-            mode=DeduplicationMode.FAST,
+            mode=DeduplicationMode.NORMAL,
             sort_order=SortOrder.SHORTEST_PATH,
             boost=BoostMode.SAME_SIZE
         )
@@ -233,7 +234,7 @@ class TestDeduplicationCommand:
             extensions=[".txt"],
             favourite_dirs=[],
             excluded_dirs=[str(excluded_dir)],  # ← NEW: exclude directory
-            mode=DeduplicationMode.FAST,
+            mode=DeduplicationMode.NORMAL,
             sort_order=SortOrder.SHORTEST_PATH,
             boost=BoostMode.SAME_SIZE
         )

--- a/tests/test_deduplicator.py
+++ b/tests/test_deduplicator.py
@@ -14,19 +14,19 @@ from onlyone.core import (
 class TestDeduplicatorIntegration:
     """Test full deduplication pipeline with real file operations."""
 
-    def test_fast_mode_finds_duplicates(self, test_files):
+    def test_normal_mode_finds_duplicates(self, test_files):
         """FAST mode should detect duplicates using size → front hash."""
         root_dir = str(Path(test_files["dup1_a"]).parent)
         params = DeduplicationParams(
-            root_dirs=[root_dir],  # ← FIXED: root_dirs as list
+            root_dirs=[root_dir],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
             favourite_dirs=[],
             excluded_dirs=[],
-            mode=DeduplicationMode.FAST,
+            mode=DeduplicationMode.NORMAL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED: required parameter
+            boost=BoostMode.SAME_SIZE
         )
         scanner = FileScanner(params=params)
         files = scanner.scan(stopped_flag=lambda: False)
@@ -51,7 +51,7 @@ class TestDeduplicatorIntegration:
         """NORMAL mode should execute size → front → middle → end stages."""
         root_dir = str(Path(test_files["dup1_a"]).parent)
         params = DeduplicationParams(
-            root_dirs=[root_dir],  # ← FIXED
+            root_dirs=[root_dir],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
@@ -59,7 +59,7 @@ class TestDeduplicatorIntegration:
             excluded_dirs=[],
             mode=DeduplicationMode.NORMAL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED
+            boost=BoostMode.SAME_SIZE
         )
         scanner = FileScanner(params=params)
         files = scanner.scan(stopped_flag=lambda: False)
@@ -78,7 +78,7 @@ class TestDeduplicatorIntegration:
         """FULL mode must execute size → front → middle → full_hash stages."""
         root_dir = str(Path(test_files["dup1_a"]).parent)
         params = DeduplicationParams(
-            root_dirs=[root_dir],  # ← FIXED
+            root_dirs=[root_dir],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
@@ -86,7 +86,7 @@ class TestDeduplicatorIntegration:
             excluded_dirs=[],
             mode=DeduplicationMode.FULL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED
+            boost=BoostMode.SAME_SIZE
         )
         scanner = FileScanner(params=params)
         files = scanner.scan(stopped_flag=lambda: False)
@@ -116,7 +116,7 @@ class TestDeduplicatorIntegration:
         file2.write_bytes(file2_content)
 
         params = DeduplicationParams(
-            root_dirs=[str(temp_dir)],  # ← FIXED
+            root_dirs=[str(temp_dir)],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024 * 1024,
             extensions=[".bin"],
@@ -124,7 +124,7 @@ class TestDeduplicatorIntegration:
             excluded_dirs=[],
             mode=DeduplicationMode.FULL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED
+            boost=BoostMode.SAME_SIZE
         )
         scanner = FileScanner(params=params)
         files = scanner.scan(stopped_flag=lambda: False)
@@ -150,7 +150,7 @@ class TestDeduplicatorIntegration:
 
         root_dir = str(Path(test_files["dup1_a"]).parent)
         params = DeduplicationParams(
-            root_dirs=[root_dir],  # ← FIXED
+            root_dirs=[root_dir],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
@@ -158,7 +158,7 @@ class TestDeduplicatorIntegration:
             excluded_dirs=[],
             mode=DeduplicationMode.NORMAL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED
+            boost=BoostMode.SAME_SIZE
         )
         scanner = FileScanner(params=params)
         files = scanner.scan(stopped_flag=lambda: False)
@@ -183,7 +183,7 @@ class TestDeduplicatorIntegration:
 
         root_dir = str(Path(test_files["dup1_a"]).parent)
         params = DeduplicationParams(
-            root_dirs=[root_dir],  # ← FIXED
+            root_dirs=[root_dir],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
@@ -191,7 +191,7 @@ class TestDeduplicatorIntegration:
             excluded_dirs=[],
             mode=DeduplicationMode.FULL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED
+            boost=BoostMode.SAME_SIZE
         )
         scanner = FileScanner(params=params)
         files = scanner.scan(stopped_flag=lambda: False)
@@ -210,15 +210,15 @@ class TestDeduplicatorIntegration:
         """Final groups should be sorted by size descending."""
         root_dir = str(Path(test_files["dup1_a"]).parent)
         params = DeduplicationParams(
-            root_dirs=[root_dir],  # ← FIXED
+            root_dirs=[root_dir],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
             favourite_dirs=[],
             excluded_dirs=[],
-            mode=DeduplicationMode.FAST,
+            mode=DeduplicationMode.NORMAL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED
+            boost=BoostMode.SAME_SIZE
         )
         scanner = FileScanner(params=params)
         files = scanner.scan(stopped_flag=lambda: False)
@@ -234,15 +234,15 @@ class TestDeduplicatorIntegration:
     def test_empty_directory_returns_empty_result(self, temp_dir):
         """Deduplication on empty directory should return zero groups."""
         params = DeduplicationParams(
-            root_dirs=[str(temp_dir)],  # ← FIXED
+            root_dirs=[str(temp_dir)],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
             favourite_dirs=[],
             excluded_dirs=[],
-            mode=DeduplicationMode.FAST,
+            mode=DeduplicationMode.NORMAL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED
+            boost=BoostMode.SAME_SIZE
         )
         scanner = FileScanner(params=params)
         files = scanner.scan(stopped_flag=lambda: False)
@@ -267,7 +267,7 @@ class TestDeduplicatorIntegration:
             extensions=[".txt"],
             favourite_dirs=[],
             excluded_dirs=[],
-            mode=DeduplicationMode.FAST,
+            mode=DeduplicationMode.NORMAL,
             sort_order=SortOrder.SHORTEST_PATH,
             boost=BoostMode.SAME_SIZE  # ← ADDED
         )
@@ -337,7 +337,7 @@ class TestDeduplicatorIntegration:
         file3.write_bytes(unique_content)
 
         params = DeduplicationParams(
-            root_dirs=[str(temp_dir)],  # ← FIXED
+            root_dirs=[str(temp_dir)],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
@@ -345,7 +345,7 @@ class TestDeduplicatorIntegration:
             excluded_dirs=[],
             mode=DeduplicationMode.NORMAL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED
+            boost=BoostMode.SAME_SIZE
         )
         scanner = FileScanner(params=params)
         files = scanner.scan(stopped_flag=lambda: False)
@@ -365,7 +365,7 @@ class TestDeduplicatorIntegration:
         """FULL mode stats must contain entries for all stages including 'full'."""
         root_dir = str(Path(test_files["dup1_a"]).parent)
         params = DeduplicationParams(
-            root_dirs=[root_dir],  # ← FIXED
+            root_dirs=[root_dir],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
@@ -373,7 +373,7 @@ class TestDeduplicatorIntegration:
             excluded_dirs=[],
             mode=DeduplicationMode.FULL,
             sort_order=SortOrder.SHORTEST_PATH,
-            boost=BoostMode.SAME_SIZE  # ← ADDED
+            boost=BoostMode.SAME_SIZE
         )
         scanner = FileScanner(params=params)
         files = scanner.scan(stopped_flag=lambda: False)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4,9 +4,8 @@ Verifies thread-safe cancellation, signal emission, and error handling.
 Updated to match new DeduplicationParams API (root_dirs list).
 """
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 from pathlib import Path
-import tempfile
 import pytest
 from onlyone.core import (
     DeduplicationParams, DeduplicationMode,
@@ -22,13 +21,13 @@ class TestDeduplicateWorker:
     def valid_params(self, tmp_path):
         """Fixture providing valid DeduplicationParams for tests."""
         return DeduplicationParams(
-            root_dirs=[str(tmp_path)],  # ← FIXED: root_dirs as list
+            root_dirs=[str(tmp_path)],
             min_size_bytes=0,
             max_size_bytes=1024 * 1024,
             extensions=[".txt"],
             favourite_dirs=[],
             excluded_dirs=[],
-            mode=DeduplicationMode.FAST,
+            mode=DeduplicationMode.NORMAL,
             sort_order=SortOrder.SHORTEST_PATH,
             boost=BoostMode.SAME_SIZE
         )


### PR DESCRIPTION
- Remove DeduplicationMode.FAST from enum and pipeline
- Update CLI and GUI to support only NORMAL and FULL modes
- Replace FAST with NORMAL in unit tests
- Simplify deduplication logic and improve accuracy